### PR TITLE
Crash when polling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,3 +2,4 @@
 
   * Start bug "Crash when polling"
   https://www.pivotaltracker.com/story/show/152151421
+  https://github.com/zvelo/zapi/pull/1

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,4 @@
+2017-10-20  Bob Uhl <buhl@zvelo.com>
+
+  * Start bug "Crash when polling"
+  https://www.pivotaltracker.com/story/show/152151421

--- a/poll.go
+++ b/poll.go
@@ -148,6 +148,9 @@ func pollReqID(ctx context.Context, reqID, url string) (bool, error) {
 func pollREST(ctx context.Context, reqID string) (*msg.QueryResult, string, error) {
 	var resp *http.Response
 	result, err := restV1Client.Result(ctx, reqID, zapi.Response(&resp))
+	if err != nil {
+		return nil, "", errors.Wrap(err, "couldn't get result from client")
+	}
 	traceID := resp.Header.Get("uber-trace-id")
 	return result, traceID, err
 }

--- a/poll.go
+++ b/poll.go
@@ -145,13 +145,12 @@ func pollReqID(ctx context.Context, reqID, url string) (bool, error) {
 	return result.QueryStatus.Complete, nil
 }
 
-func pollREST(ctx context.Context, reqID string) (*msg.QueryResult, string, error) {
+func pollREST(ctx context.Context, reqID string) (result *msg.QueryResult, traceID string, err error) {
 	var resp *http.Response
-	result, err := restV1Client.Result(ctx, reqID, zapi.Response(&resp))
-	if err != nil {
-		return nil, "", errors.Wrap(err, "couldn't get result from client")
+	result, err = restV1Client.Result(ctx, reqID, zapi.Response(&resp))
+	if result != nil {
+		traceID = resp.Header.Get("uber-trace-id")
 	}
-	traceID := resp.Header.Get("uber-trace-id")
 	return result, traceID, err
 }
 

--- a/poll_test.go
+++ b/poll_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	zapi "zvelo.io/go-zapi"
+	"zvelo.io/msg/mock"
+)
+
+// TestPollREST is a regression test for a previous version of
+// pollREST which crashed due to an unchecked error return.
+func TestPollREST(t *testing.T) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		l      net.Listener
+		err    error
+	)
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	if l, err = net.Listen("tcp", "localhost:0"); err != nil {
+		t.Error(err)
+	}
+	go func() {
+		var err error
+		if err = mock.APIv1().ServeTLS(ctx, l); err != nil {
+			t.Error(err)
+		}
+	}()
+	restV1Client = zapi.NewREST(nil, zapi.WithAddr(l.Addr().String()))
+	// This should fail due to a TLS certificate error
+	if _, _, err = pollREST(context.Background(), "22d29585-0204-406f-9941-ed15340c4c0f"); err == nil {
+		t.Error("request which should have failed … succeeded instead")
+	}
+}


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x926395]

goroutine 1 [running]:
main.pollREST(0xdb7ee0, 0xc4202bfb60, 0xc4204712c0, 0x1c, 0x2, 0xc42036d874, 0x2, 0x700000000000002, 0xffffffffffffffff)
        $HOME/src/zvelo.io/zapi/poll.go:151 +0x135
main.pollReqID(0xdb7ee0, 0xc4202bfb60, 0xc4204712c0, 0x1c, 0x7ffd682c917f, 0xe, 0xc420369700, 0x0, 0x0)
        $HOME/src/zvelo.io/zapi/poll.go:117 +0x158
main.pollReqIDs(0xdb7ee0, 0xc4202bfb60, 0x0, 0x7)
        $HOME/src/zvelo.io/zapi/poll.go:84 +0x1d0
main.queryWait(0xdb7ee0, 0xc4202bfb60, 0xc4201c7040, 0x34, 0xc42045a440, 0x2, 0x2, 0xc42044fa20, 0x0)
        $HOME/src/zvelo.io/zapi/query.go:435 +0x525
main.queryREST(0xdb7ee0, 0xc4202bfb60, 0xd18c2e2800, 0xdb7ee0)
        $HOME/src/zvelo.io/zapi/query.go:299 +0x19b
main.query(0xc420286580, 0x0, 0x0)
        $HOME/src/zvelo.io/zapi/query.go:286 +0xb0
zvelo.io/zapi/vendor/github.com/urfave/cli.HandleAction(0x9a1e40, 0xaab290, 0xc420286580, 0xc4202bfa00, 0x0)
        $HOME/src/zvelo.io/zapi/vendor/github.com/urfave/cli/app.go:490 +0xd2
zvelo.io/zapi/vendor/github.com/urfave/cli.Command.Run(0xa7aedd, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa83942, 0xf, 0x0, ...)
        $HOME/src/zvelo.io/zapi/vendor/github.com/urfave/cli/command.go:210 +0xa95
zvelo.io/zapi/vendor/github.com/urfave/cli.(*App).Run(0xc42026e000, 0xc420010080, 0x8, 0x8, 0x0, 0x0)
        $HOME/src/zvelo.io/zapi/vendor/github.com/urfave/cli/app.go:255 +0x6f8
main.main()
        $HOME/src/zvelo.io/zapi/main.go:181 +0x55
```