### PR TITLE
support alternate datasets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,6 @@
-2017-11-21  Luke <lkingland@zvelo.com>
-
-  * Start feature "support alternate datasets"
-  https://www.pivotaltracker.com/story/show/153062172
-
 2017-10-20  Bob Uhl <buhl@zvelo.com>
 
   * Start bug "Crash when polling"
   https://www.pivotaltracker.com/story/show/152151421
   https://github.com/zvelo/zapi/pull/1
+  https://github.com/zvelo/zapi/pull/3

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-11-21  Luke <lkingland@zvelo.com>
+
+  * Start feature "support alternate datasets"
+  https://www.pivotaltracker.com/story/show/153062172
+
 2017-10-20  Bob Uhl <buhl@zvelo.com>
 
   * Start bug "Crash when polling"


### PR DESCRIPTION
The zapi tool currently always requests CATEGORIZATION dataset (the default).  Debug and enable the `--datasets` flag (`ZVELO_DATASETS` environment variable) to request MALICIOUS or others.

PIVOTAL_TRACKER_STORY_URL=https://www.pivotaltracker.com/story/show/153062172
PIVOTAL_TRACKER_STORY_ESTIMATE=1
PIVOTAL_TRACKER_STORY_REQUESTER=drekar